### PR TITLE
Remove many unnecessary dependencies

### DIFF
--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -14,31 +14,12 @@
         "drupal/core-composer-scaffold": "^8.8.1",
         "drupal/core-recommended": "^8.8",
         "pantheon-systems/drupal-integrations": "^8",
-        "pantheon-systems/quicksilver-pushback": "^2",
         "drush/drush": "~8.3",
         "drupal/console": "^1",
         "cweagans/composer-patches": "^1.0",
         "drupal/config_direct_save": "^1.0",
         "drupal/config_installer": "^1.0",
-        "drush-ops/behat-drush-endpoint": "^9.3",
         "rvtraveller/qs-composer-installer": "^1.1",
         "zaporylie/composer-drupal-optimizations": "^1.0"
-    },
-    "require-dev": {
-        "behat/behat": "3.*",
-        "behat/mink": "^1.7",
-        "behat/mink-extension": "^2.2",
-        "behat/mink-goutte-driver": "^1.2",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-        "dmore/behat-chrome-extension": "^1.3",
-        "drupal/coder": "^8.3.1",
-        "drupal/drupal-extension": "~3",
-        "genesis/behat-fail-aid": "^2.1",
-        "jcalderonzumba/gastonjs": "^1.0.2",
-        "jcalderonzumba/mink-phantomjs-driver": "^0.3.1",
-        "mikey179/vfsstream": "^1.2",
-        "phpunit/phpunit": "^6.5",
-        "squizlabs/php_codesniffer": "^3.4.0",
-        "symfony/css-selector": "^2.8"
     }
 }


### PR DESCRIPTION
I noticed that the version of this repo that @stevector modified for
Drupal 9 removed a lot of the dependencies, in particular require-dev.
This makes sense to me because
 * This repo doesn't have anything like a particular CI workflow we
encourage folks to use that actually makes use of these dependencies
 * The more dependencies we start off with, the more things we/custom
upstream maintainers that fork this need to keep an eye on over time
(unsupported major versions etc.)

This would make the drupal 8 repo consistent with the drupal 9 one in
terms of not starting off with these things.